### PR TITLE
Refresh docs for v1.2.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,20 +47,24 @@ Always run `make test` before submitting changes. Tests live in `tests/` with sh
 
 ```
 ├── pipeline.py          # Pipeline orchestration, error classification, retry logic
-├── tsg_constants.py     # TSG template, stage prompts, REQUIRED_TSG_HEADINGS, validate_tsg_output()
-├── web_app.py           # Flask server, SSE streaming, setup/iteration endpoints
+├── tsg_constants.py     # TSG template, stage prompts, REQUIRED_TSG_HEADINGS, validate_tsg_output(), ensure_required_diagnosis_line()
+├── web_app.py           # Flask server, SSE streaming, setup/iteration/session/feedback endpoints
 ├── pii_check.py         # PII detection gate (Azure AI Language)
+├── model_policy.py      # Supported-model classifier (dependency-free)
 ├── error_utils.py       # Shared Azure SDK error classification
+├── error_messages.py    # Shared error hint/message constants
+├── quality_taxonomy.py  # Shared enums for feedback + evals (outcomes, failure modes)
 ├── telemetry.py         # Anonymous usage telemetry
 ├── version.py           # Single source of truth: APP_VERSION, GITHUB_URL, TSG_SIGNATURE
 ├── validate_setup.py    # CLI environment validation
 ├── build_exe.py         # PyInstaller build (bundles templates/ + static/)
 ├── delete_agents.py     # Agent cleanup utility
 ├── templates/index.html # Web UI HTML
-├── static/js/main.js    # Core UI logic (SSE, rendering, copy/download, PII modal)
+├── static/js/main.js    # Core UI logic (SSE, rendering, copy/download, PII modal, feedback, sessions)
 ├── static/js/setup.js   # Setup wizard client logic
 ├── static/css/styles.css# CSS custom properties + component styles
 ├── tests/               # Pytest suite (conftest.py has shared fixtures)
+├── evals/               # Offline deterministic TSG eval harness (make eval)
 ├── docs/                # architecture.md, telemetry.md, releasing.md
 └── examples/            # Test inputs and expected outputs
 ```
@@ -96,5 +100,5 @@ Always run `make test` before submitting changes. Tests live in `tests/` with sh
 
 ## Version Management
 
-Update `APP_VERSION` in `version.py`, tag `v{version}`, push tag to trigger the CI release workflow (`.github/workflows/build.yml`).
+Changes land on `main` through pull requests (branch protection requires it). To release: open a PR that updates `APP_VERSION` in `version.py`, merge it, then tag `v{version}` on `main` and push the tag to trigger the CI release workflow (`.github/workflows/build.yml`). See `docs/releasing.md`.
 

--- a/.github/instructions/setup-telemetry.instructions.md
+++ b/.github/instructions/setup-telemetry.instructions.md
@@ -21,5 +21,5 @@ These instructions apply when editing setup validation, model policy, agent meta
 
 - Telemetry is anonymous and fail-silent.
 - Never collect note content, generated TSG content, follow-up answers, file paths, resource names, project endpoints, agent names, secrets, or raw exception text.
-- For user-submitted signals (e.g. the `tsg_feedback` event), validate every field against a closed enum server-side and reject anything out-of-enum — this is the PII boundary. Shared feedback/eval enums live in `quality_taxonomy.py`.
+- For user-submitted signals (e.g. the `tsg_feedback` event), validate enum fields server-side against a closed vocabulary and reject out-of-enum values; clamp or drop numeric buckets to prevent high-cardinality dimensions — this is the PII boundary. Shared feedback/eval enums live in `quality_taxonomy.py`.
 - Document any event or property changes in `docs/telemetry.md` and test them.

--- a/.github/instructions/setup-telemetry.instructions.md
+++ b/.github/instructions/setup-telemetry.instructions.md
@@ -21,4 +21,5 @@ These instructions apply when editing setup validation, model policy, agent meta
 
 - Telemetry is anonymous and fail-silent.
 - Never collect note content, generated TSG content, follow-up answers, file paths, resource names, project endpoints, agent names, secrets, or raw exception text.
+- For user-submitted signals (e.g. the `tsg_feedback` event), validate every field against a closed enum server-side and reject anything out-of-enum — this is the PII boundary. Shared feedback/eval enums live in `quality_taxonomy.py`.
 - Document any event or property changes in `docs/telemetry.md` and test them.

--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ The setup wizard opens automatically to guide you through configuration.
 - 📝 Paste notes directly in the browser
 - 🖼️ **Image support** — Attach screenshots via drag-and-drop or file picker
 - 🔄 Interactive follow-up questions
-- � **Save & resume** — Persist in-progress work (notes, images, TSG, iteration state) and pick it back up later, even after restarting
-- �📋 One-click copy to clipboard
+- 💾 **Save & resume** — Persist in-progress work (notes, images, TSG, iteration state) and pick it back up later, even after restarting
+- 👍 **Quality feedback** — Optionally record how each TSG turned out (anonymous; no note content collected)
+- 📋 One-click copy to clipboard
 - 👁️ **Raw/Preview toggle** — Switch between raw markdown and rendered preview
 - 📊 Real-time status indicators
 - 💡 Load example input with one click
@@ -223,7 +224,7 @@ TSG Builder collects **anonymous usage telemetry** to help improve the tool. Tel
 
 ### What Is Collected
 
-- **Counts and enums** — event names (e.g. "TSG generated", "setup completed"), stage names, error classifications
+- **Counts and enums** — event names (e.g. "TSG generated", "setup completed", "TSG feedback"), stage names, error classifications
 - **Durations** — pipeline and per-stage wall-clock times
 - **Token counts** — per-stage input/output token usage (aggregate numbers, never content)
 - **Version and platform** — app version, OS platform, Python version, run mode (source/executable)
@@ -292,6 +293,7 @@ This creates executables in `dist/`:
 | `make test-cov` | Run tests with coverage report |
 | `make test-unit` | Run only unit tests (fast) |
 | `make test-quick` | Skip dep install (fastest) |
+| `make eval` | Run offline deterministic TSG evals (no Azure) |
 | `make help` | Show all commands |
 
 ### Architecture

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,19 +146,24 @@ When the TSG has missing information:
 | `pipeline.py` | Multi-stage pipeline orchestration, error classification |
 | `tsg_constants.py` | TSG template, agent instructions, and stage prompts |
 | `pii_check.py` | PII detection via Azure AI Language API (pre-flight gate) |
+| `model_policy.py` | Supported-model classifier (dependency-free) |
 | `error_utils.py` | Shared Azure SDK error classification utilities |
+| `error_messages.py` | Shared error hint/message constants |
+| `quality_taxonomy.py` | Shared enums for feedback + evals (outcomes, failure modes) |
 | `telemetry.py` | Anonymous usage telemetry (see [docs/telemetry.md](telemetry.md)) |
 | `version.py` | Single source of truth for version, GitHub URL, and TSG signature |
-| `web_app.py` | Flask web UI + agent creation |
+| `web_app.py` | Flask web UI, agent creation, session persistence, feedback |
 | `build_exe.py` | PyInstaller build script (bundles templates/, static/) |
 | `validate_setup.py` | Validate environment configuration (CLI troubleshooting) |
 | `delete_agents.py` | Delete agents from Azure (used by `make clean DELETE_AGENTS=1`) |
-| `Makefile` | Common operations (setup, ui, test, build, clean) |
+| `Makefile` | Common operations (setup, ui, test, build, eval, clean) |
 | `templates/index.html` | Web UI HTML structure |
 | `static/css/styles.css` | Web UI styles |
-| `static/js/main.js` | Core application logic (streaming, TSG display, images, PII modal) |
+| `static/js/main.js` | Core application logic (streaming, TSG display, images, PII modal, feedback, sessions) |
 | `static/js/setup.js` | Setup modal functionality |
 | `.agent_ids.json` | Stores agent IDs after creation |
+| `.sessions/` | Persisted session store (gitignored; raw notes/images stay local) |
+| `evals/` | Offline deterministic TSG eval harness (`make eval`) |
 | `tests/` | Pytest test suite |
 | `tests/conftest.py` | Shared fixtures and test utilities |
 | `docs/archive/error-handling-plan.md` | Error handling implementation plan (archived) |

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -4,10 +4,10 @@ This document covers the release process and build infrastructure for TSG Builde
 
 ## Quick Reference
 
-> Remember to update the version in version.py first
+> Changes reach `main` through a pull request (branch protection requires it). Update `version.py` in that PR, merge it, then tag.
 
 ```bash
-# Create and push a release tag
+# After the version-bump PR is merged to main, from an up-to-date main:
 git tag v1.0.0
 git push origin v1.0.0
 
@@ -37,10 +37,9 @@ Tags containing `-` are automatically marked as pre-releases.
 
 ### 1. Prepare the Release
 
-1. Ensure all changes are committed and pushed to `main`
-2. **Update `APP_VERSION` in `version.py`** to match the new version (e.g., `APP_VERSION = "1.1.0"`)
-3. Verify tests pass: `make test`
-4. If prompts, tools, model policy, or agent-definition signature inputs changed, plan a release-note reminder to recreate agents
+1. Open a pull request that **updates `APP_VERSION` in `version.py`** to the new version (e.g., `APP_VERSION = "1.2.0"`), and merge it to `main` (direct pushes to `main` are blocked by branch protection)
+2. Verify tests pass: `make test`
+3. If prompts, tools, model policy, or agent-definition signature inputs changed, plan a release-note reminder to recreate agents
 
 ### 2. Create and Push Tag
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -37,8 +37,8 @@ Tags containing `-` are automatically marked as pre-releases.
 
 ### 1. Prepare the Release
 
-1. Open a pull request that **updates `APP_VERSION` in `version.py`** to the new version (e.g., `APP_VERSION = "1.2.0"`), and merge it to `main` (direct pushes to `main` are blocked by branch protection)
-2. Verify tests pass: `make test`
+1. Open a pull request that **updates `APP_VERSION` in `version.py`** to the new version (e.g., `APP_VERSION = "1.2.0"`), and ensure tests pass in the PR: `make test`
+2. Merge the PR to `main` (direct pushes to `main` are blocked by branch protection)
 3. If prompts, tools, model policy, or agent-definition signature inputs changed, plan a release-note reminder to recreate agents
 
 ### 2. Create and Push Tag

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -266,6 +266,6 @@ customEvents
 | [`pipeline.py`](../pipeline.py) | `PipelineResult` telemetry fields, token accumulation in `process_pipeline_v2_stream()`, error metadata |
 | [`build_exe.py`](../build_exe.py) | `generate_build_config()` — writes `_build_config.py` with connection string |
 | [`.github/workflows/build.yml`](../.github/workflows/build.yml) | Passes `APPINSIGHTS_CONNECTION_STRING` secret to build step |
-| [`tests/test_telemetry.py`](../tests/test_telemetry.py) | Core module unit tests (34 tests) |
-| [`tests/test_pipeline_telemetry.py`](../tests/test_pipeline_telemetry.py) | Pipeline plumbing tests (16 tests) |
-| [`tests/test_telemetry_instrumentation.py`](../tests/test_telemetry_instrumentation.py) | Instrumentation point integration tests (29 tests) |
+| [`tests/test_telemetry.py`](../tests/test_telemetry.py) | Core module unit tests |
+| [`tests/test_pipeline_telemetry.py`](../tests/test_pipeline_telemetry.py) | Pipeline plumbing tests |
+| [`tests/test_telemetry_instrumentation.py`](../tests/test_telemetry_instrumentation.py) | Instrumentation point integration tests (includes `tsg_feedback`) |


### PR DESCRIPTION
Brings tracked docs in line with the shipped v1.2.0 features (session save/load, quality feedback, eval harness, #32 fix) and adopts the PR-based release flow.

## Changes
- **README**: Save & resume + Quality feedback in Features; `make eval` in the command table.
- **docs/architecture.md**: file table now includes `model_policy.py`, `error_messages.py`, `quality_taxonomy.py`, the `.sessions/` store, and `evals/`.
- **.github/copilot-instructions.md**: refreshed folder structure; Version Management now describes the PR-based release flow.
- **docs/releasing.md**: version bumps land via PR to `main`, then tag.
- **docs/telemetry.md**: removed drift-prone hardcoded test counts; noted `tsg_feedback`.
- **setup-telemetry instructions**: documented the closed-enum PII boundary for user-submitted feedback.

Docs-only; no code changes.